### PR TITLE
sh.poac.pmはリダイレクトしているため、curlには-Lオプションが必要

### DIFF
--- a/hosting/elm/Views/Index.elm
+++ b/hosting/elm/Views/Index.elm
@@ -130,7 +130,7 @@ getStartedView isFadein =
                     """
         ]
       , p [ class "code-block" ] [
-            text "$ curl https://sh.poac.pm | bash"
+            text "$ curl -L https://sh.poac.pm | bash"
         ]
       , p []
           [ text "Please refer to "


### PR DESCRIPTION
これがなければうまくインストールされない